### PR TITLE
Remove blocking semaphore, display initial state and allow large matrix

### DIFF
--- a/examples/Basics/LEDDisplay/LEDDisplay.ino
+++ b/examples/Basics/LEDDisplay/LEDDisplay.ino
@@ -10,7 +10,7 @@ void setup()
 {
     M5.begin(true, false, true);
     delay(50);
-    M5.dis.animation((uint8_t *)AtomImageData, 200, LED_Display::kMoveLeft, 18);
+    M5.dis.animation((uint8_t *)AtomImageData, 200, LED_Display::kMoveLeft, 19);
 }
 
 void loop()

--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ category=Device Control
 url=https://github.com/m5stack/M5Atom
 architectures=esp32
 includes=M5Atom.h
+depends=FastLED

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -16,7 +16,7 @@ void LED_Display::run(void *data)
 {
     data = nullptr;
 
-    for (int num = 0; num < 26; num++)
+    for (int num = 0; num < NUM_LEDS; num++)
     {
         _ledbuff[num] = 0x000000;
     }
@@ -144,7 +144,7 @@ void LED_Display::drawpix(uint8_t Number, CRGB Color)
 void LED_Display::clear()
 {
     xSemaphoreTake(_xSemaphore, portMAX_DELAY);
-    for (int8_t i = 0; i < 25; i++)
+    for (int8_t i = 0; i < NUM_LEDS; i++)
     {
         _ledbuff[i] = 0;
     }

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -26,7 +26,7 @@ void LED_Display::run(void *data)
     while (1)
     {
         xSemaphoreTake(_xSemaphore, portMAX_DELAY);
-        if (_mode == kAnmiation_run)
+        if (_mode == kAnimation_run)
         {
             if ((_am_mode & kMoveRight) || (_am_mode & kMoveLeft))
             {
@@ -55,7 +55,7 @@ void LED_Display::run(void *data)
                 _am_count--;
                 if (_am_count == 0)
                 {
-                    _mode = kAnmiation_stop;
+                    _mode = kAnimation_stop;
                 }
             }
             displaybuff(_am_buffptr, _count_x, _count_y);
@@ -77,16 +77,16 @@ void LED_Display::run(void *data)
 void LED_Display::animation(uint8_t *buffptr, uint8_t amspeed, uint8_t ammode, int64_t amcount)
 {
     xSemaphoreTake(_xSemaphore, portMAX_DELAY);
-    if (_mode == kAnmiation_run)
+    if (_mode == kAnimation_run)
     {
-        _mode = kAnmiation_stop;
+        _mode = kAnimation_stop;
     }
     _am_buffptr = buffptr;
     _am_speed = amspeed;
     _am_mode = ammode;
     _am_count = amcount;
     _count_x = _count_y = 0;
-    _mode = kAnmiation_run;
+    _mode = kAnimation_run;
     xSemaphoreGive(_xSemaphore);
 }
 

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -28,6 +28,7 @@ void LED_Display::run(void *data)
         xSemaphoreTake(_xSemaphore, portMAX_DELAY);
         if (_mode == kAnimation_run)
         {
+            displaybuff(_am_buffptr, _count_x, _count_y);
             if ((_am_mode & kMoveRight) || (_am_mode & kMoveLeft))
             {
                 if (_am_mode & kMoveRight)
@@ -58,7 +59,6 @@ void LED_Display::run(void *data)
                     _mode = kAnimation_stop;
                 }
             }
-            displaybuff(_am_buffptr, _count_x, _count_y);
             delay(_am_speed);
             delay(10);
             xSemaphoreGive(_xSemaphore);

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -90,7 +90,7 @@ void LED_Display::animation(uint8_t *buffptr, uint8_t amspeed, uint8_t ammode, i
     xSemaphoreGive(_xSemaphore);
 }
 
-void LED_Display::displaybuff(uint8_t *buffptr, int8_t offsetx, int8_t offsety)
+void LED_Display::displaybuff(uint8_t *buffptr, int32_t offsetx, int32_t offsety)
 {
     uint16_t xsize = 0, ysize = 0;
     xsize = buffptr[0];

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -99,8 +99,8 @@ void LED_Display::displaybuff(uint8_t *buffptr, int32_t offsetx, int32_t offsety
     offsetx = offsetx % xsize;
     offsety = offsety % ysize;
 
-    int8_t setdatax = (offsetx < 0) ? (-offsetx) : (xsize - offsetx);
-    int8_t setdatay = (offsety < 0) ? (-offsety) : (ysize - offsety);
+    int16_t setdatax = (offsetx < 0) ? (-offsetx) : (xsize - offsetx);
+    int16_t setdatay = (offsety < 0) ? (-offsety) : (ysize - offsety);
     for (int x = 0; x < 5; x++)
     {
         for (int y = 0; y < 5; y++)

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -1,10 +1,10 @@
 #include "LED_Display.h"
 
-LED_Display::LED_Display(uint8_t LEDNumbre)
+LED_Display::LED_Display(uint8_t LEDNumber)
 {
-    FastLED.addLeds<WS2812, DATA_PIN>(_ledbuff, LEDNumbre);
+    FastLED.addLeds<WS2812, DATA_PIN>(_ledbuff, LEDNumber);
     _xSemaphore = xSemaphoreCreateMutex();
-    _numberled = LEDNumbre;
+    _numberled = LEDNumber;
 }
 
 LED_Display::~LED_Display()
@@ -39,7 +39,7 @@ void LED_Display::run(void *data)
                     _count_x--;
                 }
             }
-            if ((_am_mode & kMoveTop) || (_am_mode & kMoveButtom))
+            if ((_am_mode & kMoveTop) || (_am_mode & kMoveBottom))
             {
                 if (_am_mode & kMoveTop)
                 {
@@ -70,6 +70,7 @@ void LED_Display::run(void *data)
         }
         
         FastLED.show();
+		FastLED.setBrightness(20);
     }
 }
 
@@ -100,7 +101,6 @@ void LED_Display::displaybuff(uint8_t *buffptr, int8_t offsetx, int8_t offsety)
 
     int8_t setdatax = (offsetx < 0) ? (-offsetx) : (xsize - offsetx);
     int8_t setdatay = (offsety < 0) ? (-offsety) : (ysize - offsety);
-    xSemaphoreTake(_xSemaphore, portMAX_DELAY);
     for (int x = 0; x < 5; x++)
     {
         for (int y = 0; y < 5; y++)
@@ -110,8 +110,6 @@ void LED_Display::displaybuff(uint8_t *buffptr, int8_t offsetx, int8_t offsety)
             _ledbuff[x + y * 5].raw[2] = buffptr[2 + ((setdatax + x) % xsize + ((setdatay + y) % ysize) * xsize) * 3 + 2];
         }
     }
-    xSemaphoreGive(_xSemaphore);
-    FastLED.setBrightness(20);
 }
 
 void LED_Display::setBrightness(uint8_t brightness)

--- a/src/utility/LED_Display.cpp
+++ b/src/utility/LED_Display.cpp
@@ -70,7 +70,7 @@ void LED_Display::run(void *data)
         }
         
         FastLED.show();
-		FastLED.setBrightness(20);
+	FastLED.setBrightness(20);
     }
 }
 

--- a/src/utility/LED_Display.h
+++ b/src/utility/LED_Display.h
@@ -46,8 +46,7 @@ public:
     void run(void *data);
 
     void animation(uint8_t *buffptr, uint8_t amspeed, uint8_t ammode, int64_t amcount = -1);
-    void displaybuff(uint8_t *buffptr, int8_t offsetx = 0, int8_t offsety = 0);
-    void MoveDisPlayBuff(int8_t offsetx = 0, int8_t offsety = 0);
+    void displaybuff(uint8_t *buffptr, int32_t offsetx = 0, int32_t offsety = 0);
 
     void setBrightness(uint8_t brightness);
     void drawpix(uint8_t xpos, uint8_t ypos, CRGB Color);

--- a/src/utility/LED_Display.h
+++ b/src/utility/LED_Display.h
@@ -28,20 +28,20 @@ public:
     enum
     {
         kStatic = 0,
-        kAnmiation_run,
-        kAnmiation_stop,
+        kAnimation_run,
+        kAnimation_stop,
     } Dismode;
     enum
     {
         kMoveRight = 0x01,
         kMoveLeft = 0x02,
         kMoveTop = 0x04,
-        kMoveButtom = 0x08,
+        kMoveBottom = 0x08,
     } Am_mode;
 
     /* data */
 public:
-    LED_Display(uint8_t LEDNumbre = 25);
+    LED_Display(uint8_t LEDNumber = NUM_LEDS);
     ~LED_Display();
     void run(void *data);
 


### PR DESCRIPTION
Actual library LED_Display animations are not working due to blocking semaphore
The initial state (offset 0,0) of the buffer is never displayed in animations
Large buffer matrix can not be displayed or wrapped around due to limited offset type
Various minor english typo corrections