### PR TITLE
Fix LED RGB to GRB

### DIFF
--- a/src/utility/LED_DisPlay.cpp
+++ b/src/utility/LED_DisPlay.cpp
@@ -2,7 +2,7 @@
 
 LED_Display::LED_Display(uint8_t LEDNumbre)
 {
-    FastLED.addLeds<WS2812, DATA_PIN>(_ledbuff, LEDNumbre);
+    FastLED.addLeds<WS2812, DATA_PIN, GRB>(_ledbuff, LEDNumbre);
     _xSemaphore = xSemaphoreCreateMutex();
     _numberled = LEDNumbre;
 }


### PR DESCRIPTION
  M5.dis.drawpix(0, CRGB::Red);
  M5.dis.drawpix(0, CRGB(255, 0, 0));

This fixes it to light up red.