### PR TITLE
Fix Stop fastled's pragma output.

### DIFF
--- a/src/M5Atom.h
+++ b/src/M5Atom.h
@@ -47,6 +47,8 @@
 
 #if defined(ESP32)
 
+#define FASTLED_INTERNAL
+
 #include <Arduino.h>
 #include <Wire.h>
 #include <FastLED.h>

--- a/src/utility/LED_Display.h
+++ b/src/utility/LED_Display.h
@@ -1,6 +1,8 @@
 #ifndef _LED_DISPLAY_H_
 #define _LED_DISPLAY_H_
 
+#define FASTLED_INTERNAL
+
 #include <FastLED.h>
 #include "utility/Task.h"
 #include <freertos/FreeRTOS.h>


### PR DESCRIPTION
pragma message "FastLED version 3.003.003"

I don't think this message is necessary.