### PR TITLE
Fix _ledbuff init

### DIFF
--- a/src/utility/LED_DisPlay.cpp
+++ b/src/utility/LED_DisPlay.cpp
@@ -16,7 +16,7 @@ void LED_Display::run(void *data)
 {
     data = nullptr;
 
-    for (int num = 0; num < 26; num++)
+    for (int num = 0; num < NUM_LEDS; num++)
     {
         _ledbuff[num] = 0x000000;
     }


### PR DESCRIPTION
#define NUM_LEDS 25
CRGB _ledbuff[NUM_LEDS];

index 0-24
Now it's a memory overrun.