### PR TITLE
Update LED_Display.h

### DIFF
--- a/src/utility/LED_Display.h
+++ b/src/utility/LED_Display.h
@@ -44,7 +44,7 @@ public:
 
     /* data */
 public:
-    LED_DisPlay(uint8_t LEDNumbre = 25);
+    LED_DisPlay(uint8_t LEDNumbre = NUM_LEDS);
     ~LED_DisPlay();
 
     void run(void *data);


### PR DESCRIPTION
Fixed call to the `LED_DisPlay` constructor to use the `NUM_LEDS` define rather than a hard-coded number of LEDs.  It's the same result, but there's no need for `NUM_LEDS` if you're not going to use it in the code.