### PR TITLE
Update LED_DisPlay.cpp

### DIFF
--- a/src/utility/LED_DisPlay.cpp
+++ b/src/utility/LED_DisPlay.cpp
@@ -16,7 +16,7 @@ void LED_DisPlay::run(void *data)
 {
     data = nullptr;
 
-    for (int num = 0; num < 25; num++)
+    for (int num = 0; num < NUM_LEDS; num++)
     {
         _ledbuff[num] = 0x000000;
     }


### PR DESCRIPTION
Fixed initialization loop to use the `NUM_LEDS` define rather than the hard-coded 25.  This makes the code more portable is M5Stack ever adds a product with more LEDs.