### PR TITLE
fix RGB_ORDER from RGB to GRB

### DIFF
--- a/src/utility/LED_DisPlay.cpp
+++ b/src/utility/LED_DisPlay.cpp
@@ -2,7 +2,7 @@
 
 LED_DisPlay::LED_DisPlay()
 {
-    
+
 }
 
 LED_DisPlay::~LED_DisPlay()
@@ -12,7 +12,7 @@ LED_DisPlay::~LED_DisPlay()
 
 void LED_DisPlay::begin(uint8_t LEDNumbre)
 {
-    FastLED.addLeds<WS2812, DATA_PIN>(_ledbuff, LEDNumbre);
+    FastLED.addLeds<WS2812, DATA_PIN, GRB>(_ledbuff, LEDNumbre);
     _xSemaphore = xSemaphoreCreateMutex();
     _numberled = LEDNumbre;
 }


### PR DESCRIPTION
Hello.
I'm sure this is a duplicate, but it hasn't been fixed yet, so I'll send a pull request.

LEDSet https://github.com/m5stack/M5Atom/issues/5

I didn't notice this bug until just now and had to look it up, so I hope for a quick fix. Please save someone's precious time.