### PR TITLE
Fix inappropriate LED display in M5.dis.displaybuff()

### DIFF
--- a/src/utility/LED_DisPlay.h
+++ b/src/utility/LED_DisPlay.h
@@ -22,7 +22,7 @@ private:
     int32_t _am_count = -1;
     uint8_t *_am_buffptr;
     uint16_t _yRows = 5;
-    uint16_t _xColumns = 6;
+    uint16_t _xColumns = 5;
 
     SemaphoreHandle_t _xSemaphore = NULL;
 


### PR DESCRIPTION
## Problem

When I use M5.dis.displaybuff(), last 4 pixels does not light appropriately.

## Solution

I think this is occurred because x offset using displaybuff() is 6, defined in LED_DisPlay.h.

https://github.com/m5stack/M5Atom/blob/ec57f8d26c61fac336e425db61082c0b8ea9cba8/src/utility/LED_DisPlay.cpp#L121
https://github.com/m5stack/M5Atom/blob/ec57f8d26c61fac336e425db61082c0b8ea9cba8/src/utility/LED_DisPlay.h#L25

So, I fixed xColumns to 5.

or use M5.dis.setWidthHeight()
```cpp
M5.dis.setWidthHeight(5, 5);
```