### PR TITLE
Invalid double quotation marks were used.

### DIFF
--- a/src/M5Atom.h
+++ b/src/M5Atom.h
@@ -79,6 +79,6 @@ class M5Atom {
 extern M5Atom M5;
 
 #else
-#error “This library only supports boards with ESP32 processor.”
+#error "This library only supports boards with ESP32 processor."
 #endif
 #endif


### PR DESCRIPTION
Instead of U+0022("), U+201C and U+201D (“”) were used.